### PR TITLE
Support Pageflow 12

### DIFF
--- a/pageflow-new-pages-box.gemspec
+++ b/pageflow-new-pages-box.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.10'
+  spec.add_runtime_dependency 'pageflow', ['>= 0.10', '< 13']
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
`0.12` will be released as `12.0`.