### PR TITLE
Get page thumbnail via helper

### DIFF
--- a/app/views/pageflow/new_pages_box/_page.html.erb
+++ b/app/views/pageflow/new_pages_box/_page.html.erb
@@ -16,7 +16,7 @@
     <%= content_tag(:div,
                     '',
                     class: "thumbnail is_#{page.template}",
-                    style: "background-image: url('#{asset_path(page.thumbnail_url(:navigation_thumbnail_large))}')") %>
+                    style: "background-image: url('#{asset_path(page_thumbnail_url(page, :navigation_thumbnail_large))}')") %>
   <% end %>
   <hr />
 <% end %>

--- a/pageflow-new-pages-box.gemspec
+++ b/pageflow-new-pages-box.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', ['>= 0.10', '< 16']
+  spec.add_runtime_dependency 'pageflow', '~> 15.x'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'


### PR DESCRIPTION
To integrate correctly with file perma ids, the page thumbnail can no
longer be accessed via `page.thumbnail_url`. There is a new helper
`page_thumbnail_url` to get the thumbnail in the context of the
currently rendered entry.

REDMINE-16809